### PR TITLE
Fix dates shifting a day behind: serialise as local wall time, not UTC

### DIFF
--- a/src/Message/AbstractMYOBRequest.php
+++ b/src/Message/AbstractMYOBRequest.php
@@ -166,6 +166,26 @@ abstract class AbstractMYOBRequest extends AbstractRequest
     }
 
     /**
+     * Serialize dates as local wall time. json_encode(Carbon) converts to UTC,
+     * which lands any AU-timezone date a day behind in MYOB.
+     *
+     * @param mixed $data
+     * @return mixed
+     */
+    public function normalizeDates($data)
+    {
+        if (is_array($data)) {
+            array_walk_recursive($data, function (&$value) {
+                if ($value instanceof \DateTimeInterface) {
+                    $value = $value->format('Y-m-d\TH:i:s');
+                }
+            });
+        }
+
+        return $data;
+    }
+
+    /**
      * Send the request with specified data
      *
      * @param  mixed $data The data to send
@@ -188,6 +208,7 @@ abstract class AbstractMYOBRequest extends AbstractRequest
             $headers = $this->getOldEssentialsHeaders($this->getHttpMethod());
         }
 
+        $data = $this->normalizeDates($data);
         $body = $data ? json_encode($data) : null;
         $fullUrl = $endpoint . $this->getEndpoint();
 

--- a/tests/DateNormalizationTest.php
+++ b/tests/DateNormalizationTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Tests;
+
+use Carbon\Carbon;
+use PHPAccounting\MyobAccountRightLive\Message\Invoices\Requests\CreateInvoiceRequest;
+use PHPUnit\Framework\TestCase;
+
+class DateNormalizationTest extends TestCase
+{
+    public function testDatesKeepLocalWallTimeInRequestBody()
+    {
+        $request = new CreateInvoiceRequest();
+
+        $data = [
+            'Date' => Carbon::parse('2026-07-07', 'Australia/Sydney'),
+            'Terms' => ['DueDate' => Carbon::parse('2026-07-14', 'Australia/Sydney')],
+        ];
+
+        $normalized = $request->normalizeDates($data);
+
+        // json_encode(Carbon) alone would produce 2026-07-06T14:00:00Z — a day behind
+        $this->assertSame('2026-07-07T00:00:00', $normalized['Date']);
+        $this->assertSame('2026-07-14T00:00:00', $normalized['Terms']['DueDate']);
+    }
+}


### PR DESCRIPTION
json_encode(Carbon) converts to UTC before formatting, so an Australia/Sydney invoice dated 2026-07-07 was sent to MYOB as 2026-07-06T14:00:00Z and stored a day behind. Normalise all DateTimeInterface values in the request body to local wall time (Y-m-d\TH:i:s, no offset) before encoding.